### PR TITLE
Remove debugging logs from clock dashboard

### DIFF
--- a/client/cz-clock-dash.html
+++ b/client/cz-clock-dash.html
@@ -80,7 +80,6 @@
       currentTimeDay: function(timezone) {
         var d = moment(new Date()).tz(timezone.timezone);
         var data = {timeString: d.format("HH:mm"), class: this.workingHours(d), offset: d.format("Z")};
-        console.log(data.timeString, data.class);
         return data;
       },
       mutateTimeString: function() {


### PR DESCRIPTION
These logs occur once per second per timezone and get in the way of debugging other components.
