### PR TITLE
Avoid adding sources to the registry multiple times

### DIFF
--- a/client/cz-registry.html
+++ b/client/cz-registry.html
@@ -11,8 +11,18 @@
     Polymer({
       is: "cz-registry",
 
+      properties: {
+        registeredSources: {
+          type: 'Object',
+          value: function() { return {}; },
+        },
+      },
+
       attached: function() {
         this.async(this.update, 300000);
+        for (var source of Polymer.dom(this).children) {
+          this.registeredSources[source.nodeName.toLowerCase()] = Promise.resolve(source);
+        }
       },
 
       update: function() {
@@ -24,26 +34,20 @@
       },
 
       registerSource: function(type, query, callback) {
-        var existingSources = Polymer.dom(this).children;
-        var source = undefined;
-        for (var i = 0; i < existingSources.length; i++) {
-          if (existingSources[i].nodeName.toLowerCase() == type) {
-            source = existingSources[i];
-            source.registerQuery(query, callback);
-            return;
-          }
+        if (!(type in this.registeredSources)) {
+          this.registeredSources[type] = new Promise(function(resolve, reject) {
+            this.importHref(type + '.html', function(e) {
+              source = document.createElement(type);
+              Polymer.dom(this).appendChild(source);
+              resolve(source);
+            }.bind(this), function(e) {
+              console.error("Couldn't load source for " + type);
+              reject(e);
+            });
+          }.bind(this));
         }
-        if (source == undefined) {
-          this.importHref(type + '.html', function(e) {
-            source = document.createElement(type);
-            Polymer.dom(this).appendChild(source);
-            source.registerQuery(query, callback);
-          }, function(e) {
-            console.error("Couldn't load source for " + type);
-          });
-        }
-        // TODO: return promise of source
-      }
+        return this.registeredSources[type].then(source => source.registerQuery(query, callback));
+      },
     });
   </script>
 

--- a/client/cz-registry.html
+++ b/client/cz-registry.html
@@ -16,13 +16,14 @@
           type: 'Object',
           value: function() { return {}; },
         },
+        scannedContentSources: {
+          type: 'boolean',
+          value: function() { return false; },
+        },
       },
 
       attached: function() {
         this.async(this.update, 300000);
-        for (var source of Polymer.dom(this).children) {
-          this.registeredSources[source.nodeName.toLowerCase()] = Promise.resolve(source);
-        }
       },
 
       update: function() {
@@ -34,6 +35,13 @@
       },
 
       registerSource: function(type, query, callback) {
+        if (!this.scannedContentSources) {
+          for (var source of Polymer.dom(this).children) {
+            this.registeredSources[source.nodeName.toLowerCase()] = Promise.resolve(source);
+          }
+          this.scannedContentSources = true;
+        }
+
         if (!(type in this.registeredSources)) {
           this.registeredSources[type] = new Promise(function(resolve, reject) {
             this.importHref(type + '.html', function(e) {
@@ -46,6 +54,7 @@
             });
           }.bind(this));
         }
+
         return this.registeredSources[type].then(source => source.registerQuery(query, callback));
       },
     });


### PR DESCRIPTION
Multiple calls to registerSource() before the importHref() callback fired would result in the source getting loaded multiple times.
This change uses a map of source names to source element Promises to ensure we don't load a source more than once.
See [before](http://i.imgur.com/sPvcdST.png) and [after](http://i.imgur.com/GmIpzRt.png) screenshots.
