### PR TITLE
Convert animations dash to new SLO scheme

### DIFF
--- a/client/cz-component-dash.html
+++ b/client/cz-component-dash.html
@@ -69,18 +69,14 @@
         var div = "<div><span style='color: white; border-radius: 4px; padding: 0px 6px;";
         if (issues == undefined)
           return "pending";
-        var priorityCounts = issues.priorityCounts();
-        var outOfUpdateSLOCounts = issues.outOfUpdateSLOCounts(updateSLO);
 
         var result = "";
-        var keys = Object.keys(priorityCounts).sort();
-        for (var key of keys) {
-          result += div + ' background-color: ' + priorityColor(key) + "'>" +
-            priorityString(key) + "</span>" +
-            "<span style='margin:0px 5px'>" + priorityCounts[key];
-          if (key in outOfUpdateSLOCounts && outOfUpdateSLOCounts[key] > 0) {
-            result += " (" + outOfUpdateSLOCounts[key] + " out of SLO)";
-          }
+        for (var summaryItem of issues.summary(updateSLO)) {
+          var level = summaryItem.level;
+          var color = summaryItem.color;
+          var summary = summaryItem.summary;
+          result += div + ' background-color: ' + color + "'>" + level + "</span>" +
+            "<span style='margin:0px 5px'>" + summary;
           result += "</span></div>";
         }
         return result;

--- a/client/cz-issue-priority-dash.html
+++ b/client/cz-issue-priority-dash.html
@@ -20,16 +20,15 @@
       }
 
       paper-item {
-        width: 50%;
         box-sizing: border-box;
       }
     </style>
-      <paper-card heading="Issue Priorities" id='card'>
+      <paper-card heading="Assigned Issues" id='card'>
         <div class="card-content">
 
           <div class='card-flex'>
             <template is="dom-repeat" items="{{users}}"
-                      filter="filterUsers" sort="sortUsers"
+                      filter="filterUsers"
                       observe="issues">
               <paper-item>
                 <paper-item-body two-line>
@@ -66,18 +65,6 @@
         return item.issues.length() > 0;
       },
 
-      sortUsers(a, b) {
-        if (a.issues == undefined || b.issues == undefined)
-          return 0;
-        var minPriorityA = a.issues.minPriority();
-        var minPriorityB = b.issues.minPriority();
-        if (minPriorityA < minPriorityB)
-          return -1;
-        if (minPriorityA > minPriorityB)
-          return 1;
-        return 0;
-      },
-
       attached: function() {
         registerSource('cz-config', 'users', function(users) {
           this.set('users', users);
@@ -91,18 +78,14 @@
         var div = "<div><span style='color: white; border-radius: 4px; padding: 0px 6px;";
         if (issues == undefined)
           return "pending"
-        var priorityCounts = issues.priorityCounts();
-        var outOfUpdateSLOCounts = issues.outOfUpdateSLOCounts(updateSLO);
 
         var result = "";
-        var keys = Object.keys(priorityCounts).sort();
-        for (var key of keys) {
-          result += div + " background-color: " + priorityColor(key) + "'>" +
-            priorityString(key) + "</span>" +
-            "<span style='margin:0px 5px'>" + priorityCounts[key];
-          if (key in outOfUpdateSLOCounts && outOfUpdateSLOCounts[key] > 0) {
-            result += " (" + outOfUpdateSLOCounts[key] + " out of SLO)";
-          }
+        for (var summaryItem of issues.summary(updateSLO)) {
+          var level = summaryItem.level;
+          var color = summaryItem.color;
+          var summary = summaryItem.summary;
+          result += div + " background-color: " + color + "'>" + level + "</span>" +
+            "<span style='margin:0px 5px'>" + summary;
           result += "</span></div>";
         }
         return result;

--- a/configs/animations-ave.json
+++ b/configs/animations-ave.json
@@ -10,10 +10,10 @@
   {"name": "Internals>Compositing>Animation", "cardHeading": "Compositor Tickets"}
 ],
 "updateSLO": {
-  "0": "1",
-  "1": "7",
-  "2": "14",
-  "3": "180"
+  "daily": "1",
+  "weekly": "7",
+  "fortnightly": "14",
+  "monthly": "30"
 },
 "dashes": [
   "cz-clock-dash",


### PR DESCRIPTION
- Add reviewLevel to Issue that corresponds to Update-\* label of new bug update
  SLO scheme.
- Update updateSLO entry in configs/animations-ave.json.
- Add reviewLevelWithBackoff() to append priority value in order to subdivide
  bugs that don't yet have an Update-\* label.
- Move more logic for summarising issues from cz-issue-priority-dash and
  cz-component-dash to issues-lib.
- Remove sorting of users in cz-issue-priority-dash.
- Use Math.floor instead of Math.round when calculating number of days since
  issue last updated.
