### PR TITLE
Fetch all results for query instead of first 100

### DIFF
--- a/redirect.py
+++ b/redirect.py
@@ -26,7 +26,9 @@ class MainPage(webapp2.RequestHandler):
       if self.request.get('site') == 'issues':
           urlfetch.set_default_fetch_deadline(10)
           self.response.headers.add_header("Access-Control-Allow-Origin", "*")
-          result = monorail.issues().list(projectId='chromium', q=self.request.get('q'), can='open').execute()
+          initialResponse = monorail.issues().list(projectId='chromium', q=self.request.get('q'), can='open', maxResults=1).execute()
+          numResults = initialResponse["totalResults"]
+          result = monorail.issues().list(projectId='chromium', q=self.request.get('q'), can='open', maxResults=numResults).execute()
           self.response.write(json.dumps(result))
       elif self.request.get('site') == 'issue':
           urlfetch.set_default_fetch_deadline(10)


### PR DESCRIPTION
The monorail.issues().list(..) query by default only returns the first 100
issues. This patch changes the code to send an initial query for the first 1
issue, which also specifies the total number of results available, and then
sends a follow-up query to fetch the entire list.

This addresses https://github.com/shans/chromez/issues/19
