### PR TITLE
Make milestone label detection not case sensitive

### DIFF
--- a/client/cz-milestones-dash.html
+++ b/client/cz-milestones-dash.html
@@ -135,7 +135,7 @@
             for (var i = 0; i < data.length; i++) {
               for (var j = 0; j < data[i].labels.length; j++) {
                 var label = data[i].labels[j];
-                if (label.substring(0, 2) == 'M-') {
+                if (label.substring(0, 2).toLowerCase() == 'm-') {
                   data[i].M = label.substring(2);
                   break;
                 }

--- a/client/cz-regression-dash.html
+++ b/client/cz-regression-dash.html
@@ -89,7 +89,7 @@
           for (var issue of issues) {
             var version = null;
             for (var label of issue.labels) {
-              if (label.indexOf('M-') == 0) {
+              if (label.substring(0, 2).toLowerCase() == 'm-') {
                 version = Number(label.substring(2));
               }
             }


### PR DESCRIPTION
Some milestone labels start with a lower case "m" e.g. https://bugs.chromium.org/p/chromium/issues/detail?id=355359.
