### PR TITLE
Make cz-issue-priority-dash use templates instead of innerHTML

### DIFF
--- a/client/cz-issue-priority-dash.html
+++ b/client/cz-issue-priority-dash.html
@@ -22,6 +22,16 @@
       paper-item {
         box-sizing: border-box;
       }
+
+      .bubble {
+        color: white;
+        border-radius: 4px;
+        padding: 0px 6px;
+      }
+
+      .summary {
+        margin: 0px 5px;
+      }
     </style>
       <paper-card heading="Assigned Issues" id='card'>
         <div class="card-content">
@@ -33,8 +43,14 @@
               <paper-item>
                 <paper-item-body two-line>
                   <div>{{item.user}}</div>
-                  <!-- TODO(suzyh): convert to templatized HTML -->
-                  <div secondary inner-h-t-m-l="[[priorities(item.issues, updateSLO)]]" class='priorities'></div>
+                  <div secondary class='priorities'>
+                    <template is="dom-repeat" items="{{priorities(item.issues, updateSLO)}}">
+                      <div>
+                        <span class="bubble" style="background-color: {{item.color}}">{{item.level}}</span>
+                        <span class="summary">{{item.summary}}</span>
+                      </div>
+                    </template>
+                  </div>
                 </paper-item-body>
               </paper-item>
             </template>
@@ -75,20 +91,7 @@
       },
 
       priorities: function(issues, updateSLO) {
-        var div = "<div><span style='color: white; border-radius: 4px; padding: 0px 6px;";
-        if (issues == undefined)
-          return "pending"
-
-        var result = "";
-        for (var summaryItem of issues.summary(updateSLO)) {
-          var level = summaryItem.level;
-          var color = summaryItem.color;
-          var summary = summaryItem.summary;
-          result += div + " background-color: " + color + "'>" + level + "</span>" +
-            "<span style='margin:0px 5px'>" + summary;
-          result += "</span></div>";
-        }
-        return result;
+        return issues.summary(updateSLO);
       },
 
       usersChanged: function(users) {


### PR DESCRIPTION
No change in behaviour, fixing existing TODO.
Note the check for "issues == undefined" was unnecessary due to the filter="filterUsers" guard in the outer template.
