### PR TITLE
s/pre-stable/old/

### DIFF
--- a/client/cz-regression-dash.html
+++ b/client/cz-regression-dash.html
@@ -112,7 +112,7 @@
 
       regressionCounts: function(releases, regressionVersions) {
         return [{
-          label: 'pre-stable \u2264' + (releases.stable - 1),
+          label: 'old \u2264' + (releases.stable - 1),
           color: '#B90D00',
           count: regressionVersions.filter(version => version < releases.stable).length,
         }, {


### PR DESCRIPTION
The name pre-stable is ambiguous. This change renames it to "old".
