### PR TITLE
Use // instead of http:// for crbug redirect links

### DIFF
--- a/client/cz-issues.html
+++ b/client/cz-issues.html
@@ -12,7 +12,7 @@
         auto
         params="{{item.params}}"
         handle-as="text"
-        url="http://chromez-app.appspot.com/redirect/?"
+        url="//chromez-app.appspot.com/redirect/?"
         on-response="handleResponse"
         content-type='text/plain'
         verbose=true></iron-ajax>


### PR DESCRIPTION
https://chromez-app.appspot.com/#configs/blink.json does not work with using HTTP redirect.
This change makes it use the same as the current protocol.
