### PR TITLE
Remove use of Object.values()

### DIFF
--- a/client/cz-regression-dash.html
+++ b/client/cz-regression-dash.html
@@ -81,7 +81,7 @@
           this.set('releases', releases);
         }.bind(this));
         registerSource('cz-config', 'components', function(components) {
-          this.set('components', Object.values(components));
+          this.set('components', Object.keys(components).map(name => components[name]));
         }.bind(this));
       },
 


### PR DESCRIPTION
Object.values() has not shipped in Chrome yet and is still behind a flag, use Object.keys().map() instead.
