### PR TITLE
Use HTTPS links for data sources instead of HTTP

### DIFF
--- a/client/cz-releases.html
+++ b/client/cz-releases.html
@@ -9,7 +9,7 @@
       <iron-ajax
         auto
         params="{{item.params}}"
-        url="http://omahaproxy.appspot.com/all.json"
+        url="https://omahaproxy.appspot.com/all.json"
         on-response="handleResponse"
         verbose=true></iron-ajax>
     </template>

--- a/client/cz-review-latency-card.html
+++ b/client/cz-review-latency-card.html
@@ -54,7 +54,7 @@
       },
 
       issueLink(number) {
-        return "http://codereview.chromium.org/" + number;
+        return "https://codereview.chromium.org/" + number;
       }
 
     });


### PR DESCRIPTION
Using HTTP for JSON in an HTTPS page makes Chrome sad.

![screenshot](http://i.imgur.com/q4SYSSk.png)
