### PR TITLE
Make review latency summary card optional

### DIFF
--- a/client/cz-review-latency-dash.html
+++ b/client/cz-review-latency-dash.html
@@ -37,6 +37,7 @@
       }
 
     </style>
+    <template is="dom-if" if="{{showSummary}}">
       <paper-card id='card' heading='Pending Code Review Latency'>
         <div class="card-content">
           <div class='card-flex'>
@@ -64,6 +65,7 @@
           </div>
         </div>
       </paper-card>
+    </template>
   </template>
 
   <script>
@@ -105,6 +107,7 @@
       },
 
       attached: function() {
+        this.set('showSummary', this.key == 'true');
         registerSource('cz-config', 'users', function(users) {
           this.set('users', users);
         }.bind(this));

--- a/configs/animations-ave.json
+++ b/configs/animations-ave.json
@@ -21,7 +21,7 @@
   "cz-component-dash(compositing)",
   "cz-issue-priority-dash",
   "cz-regression-dash",
-  "cz-review-latency-dash",
+  "cz-review-latency-dash(false)",
   "cz-review-load-dash"
 ],
 "timezones": [

--- a/configs/blink.json
+++ b/configs/blink.json
@@ -17,7 +17,13 @@
   {"user": "Sasha", "email": "sashab@chromium.org"},
   {"user": "Tim Ansell", "email": "mithro@mithis.com"}
 ],
-"dashes": ["cz-clock-dash", "cz-review-latency-dash", "cz-review-load-dash", "cz-calendar-feed-source", "cz-shields-dash(customelements)"],
+"dashes": [
+  "cz-clock-dash",
+  "cz-review-latency-dash(true)",
+  "cz-review-load-dash",
+  "cz-calendar-feed-source",
+  "cz-shields-dash(customelements)"
+],
 "timezones": [
   {"city": "MTV", "timezone": "US/Pacific"},
   {"city": "Waterloo", "timezone": "America/Nipigon"},


### PR DESCRIPTION
For the Animations dashboard, we'd like to be able to display the per-person
code review cards without the code review latency summary card. This patch gives
cz-review-latency-dash an argument to indicate whether the summary card is shown
or not, with the blink.json config including the summary and animations-ave.json
config not including it.
