### PR TITLE
Add github integration to Animations Ave config

### DIFF
--- a/client/cz-shields-dash.html
+++ b/client/cz-shields-dash.html
@@ -20,7 +20,7 @@
         margin: 8px 8px 8px 0;
       }
     </style>
-      <paper-card heading="[[repo]]" id="card">
+      <paper-card heading="[[name]]" id="card">
         <div class="card-content">
           <div class='card-flex'>
             <template is="dom-repeat" items="{{data}}">
@@ -51,6 +51,7 @@
         registerSource('cz-config', 'github', github => {
           this.set('shields', github[this.key].shields);
           this.set('repo', github[this.key].repo);
+          this.set('name', github[this.key].name);
         });
       },
 

--- a/configs/animations-ave.json
+++ b/configs/animations-ave.json
@@ -22,12 +22,26 @@
   "cz-issue-priority-dash",
   "cz-regression-dash",
   "cz-review-latency-dash(false)",
-  "cz-review-load-dash"
+  "cz-review-load-dash",
+  "cz-shields-dash(web-animations-js)",
+  "cz-shields-dash(web-animations-next)"
 ],
 "timezones": [
   {"city": "MTV", "timezone": "US/Pacific"},
   {"city": "Waterloo", "timezone": "America/Nipigon"},
   {"city": "Tokyo", "timezone": "Asia/Tokyo"},
   {"city": "Sydney", "timezone": "Australia/Sydney", "local": true}
-  ]
+],
+"github": {
+  "web-animations-js": {
+    "name": "web-animations-js",
+    "repo": "web-animations/web-animations-js",
+    "shields": ["travis", "github/issues-pr", "github/issues"]
+  },
+  "web-animations-next": {
+    "name": "web-animations-next",
+    "repo": "web-animations/web-animations-next",
+    "shields": ["travis", "github/issues-pr", "github/issues"]
+  }
+}
 }

--- a/configs/blink.json
+++ b/configs/blink.json
@@ -31,6 +31,6 @@
   {"city": "Sydney", "timezone": "Australia/Sydney", "local": true}
   ],
 "github": {
-  "customelements": { "repo": "customelements/v2", "shields": ["travis", "github/issues-pr", "github/issues"] }
+  "customelements": { "name": "customelements/v2", "repo": "customelements/v2", "shields": ["travis", "github/issues-pr", "github/issues"] }
 }
 }


### PR DESCRIPTION
This patch adds cards for the web-animations-js and web-animations-next github
repositories to the Animations Ave config. The config is extended to allow a
configurable card heading.
