### PR TITLE
Remove I>C>A component from Animations Ave dash

### DIFF
--- a/configs/animations-ave.json
+++ b/configs/animations-ave.json
@@ -6,8 +6,7 @@
   {"user": "Alexey", "email": "loyso@chromium.org"}
 ],
 "components": {
-  "animation": "Blink>Animation",
-  "compositing": "Internals>Compositing>Animation"
+  "animation": "Blink>Animation"
 },
 "updateSLO": {
   "daily": "1",
@@ -18,7 +17,6 @@
 "dashes": [
   "cz-clock-dash",
   "cz-component-dash(animation)",
-  "cz-component-dash(compositing)",
   "cz-issue-priority-dash",
   "cz-regression-dash",
   "cz-review-latency-dash(false)",


### PR DESCRIPTION
The Animations Ave dashboard no longer needs to display data about the
Internals>Compositing>Animation Monorail component.
