### PR TITLE
Enable configuration of the number of columns used by the cardview

### DIFF
--- a/client/cz-cardview.html
+++ b/client/cz-cardview.html
@@ -153,6 +153,11 @@
 
       attached: function() {
         registerSource('cz-config', 'cardview-heading', cvHeading => this.set('cardview-heading', (cvHeading ? cvHeading : 'Card Feed')));
+        registerSource('cz-config', 'cardview-columns', cvColumns => {
+          if (cvColumns) {
+            this.set('columns', cvColumns);
+          }
+        });
         this.last = {};
       },
 

--- a/client/cz-cardview.html
+++ b/client/cz-cardview.html
@@ -153,11 +153,7 @@
 
       attached: function() {
         registerSource('cz-config', 'cardview-heading', cvHeading => this.set('cardview-heading', (cvHeading ? cvHeading : 'Card Feed')));
-        registerSource('cz-config', 'cardview-columns', cvColumns => {
-          if (cvColumns) {
-            this.set('columns', cvColumns);
-          }
-        });
+        registerSource('cz-config', 'cardview-columns', cvColumns => this.columns = cvColumns);
         this.last = {};
       },
 

--- a/configs/animations-ave.json
+++ b/configs/animations-ave.json
@@ -1,4 +1,5 @@
 {"cardview-heading": "Welcome to Animations Avenue (go/animations-ave)",
+"cardview-columns": 1,
 "users": [
   {"user": "Eric", "email": "ericwilligers@chromium.org"},
   {"user": "Alan", "email": "alancutter@chromium.org"},


### PR DESCRIPTION
animations-ave.json typically has very few cards, we should reduce the amount of unused space when our regular dashes are reaching their space limits.
