### PR TITLE
Fix bug where closured query variable was getting erroneously mutated.

### DIFF
--- a/client/cz-crbug-issues.html
+++ b/client/cz-crbug-issues.html
@@ -40,12 +40,10 @@
           });
         }
 
-        function getQueryURL(subQuery) {
-          if (subQuery) {
-            query = clone(query);
-            Object.assign(query, subQuery);
-          }
-          return Crbug.queryURL(query);
+        function getQueryURL(subQuery = {}) {
+          var urlQuery = clone(query);
+          Object.assign(urlQuery, subQuery);
+          return Crbug.queryURL(urlQuery);
         }
 
         function getUsername(userConfig) {


### PR DESCRIPTION
This bug was causing URLs like https://bugs.chromium.org/p/chromium/issues/list?can=2&q=component%3DBlink%3EAnimation%20label%3DUpdate-Quarterly%20-has%3DUpdate to be generated. Notice that this searches for both `label=Update-Quarterly` and `-has=Update` which never yields results.