### PR TITLE
Gcloud deploy update

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,8 @@
+Make sure you've installed pip and gcloud!
+
+in ```chromez/```:
+
+1.  ```mkdir lib```
+2.  ```pip install -t lib/ oauth2client```
+3. ```gcloud config set project chromez-app```
+4. ```gcloud app deploy --version 1 app.yaml```

--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,3 @@
-application: chromez-app
-version: 1
 runtime: python27
 api_version: 1
 threadsafe: true


### PR DESCRIPTION
gcloud doesn't want app.yaml to have an application name or version any more. Instead you configure them on the command line. I've made the change and provided some basic instructions in DEPLOY.md