### PR TITLE
Increase maximum number of Monorail results to 500

### DIFF
--- a/redirect.py
+++ b/redirect.py
@@ -26,7 +26,7 @@ class MainPage(webapp2.RequestHandler):
       if self.request.get('site') == 'issues':
           urlfetch.set_default_fetch_deadline(10)
           self.response.headers.add_header("Access-Control-Allow-Origin", "*")
-          result = monorail.issues().list(projectId='chromium', q=self.request.get('q'), can='open').execute()
+          result = monorail.issues().list(projectId='chromium', q=self.request.get('q'), can='open', maxResults=500).execute()
           self.response.write(json.dumps(result))
       elif self.request.get('site') == 'issue':
           urlfetch.set_default_fetch_deadline(10)


### PR DESCRIPTION
By default, Monorail returns 100 issues in a query. Our bug components contain more than 100 issues. Although the best thing to do here would be to implement some kind of pagination, increasing the maximum result size is a simple solution that does not require the same implementation effort.