### PR TITLE
Making all timezone secondary for Chrome iOS

### DIFF
--- a/configs/chrome-ios.json
+++ b/configs/chrome-ios.json
@@ -33,8 +33,8 @@
   "cz-review-load-dash"
 ],
 "timezones": [
-  {"city": "MTV", "timezone": "US/Pacific", "local": true},
   {"city": "RES", "timezone": "US/Eastern"},
-  {"city": "PAR", "timezone": "Europe/Paris"}
+  {"city": "PAR", "timezone": "Europe/Paris"},
+  {"city": "MTV", "timezone": "US/Pacific"}
   ]
 }


### PR DESCRIPTION
My team has been complaining that making a timezone primary is not inclusive. So making them all secondary for Chrome iOS :)